### PR TITLE
Bug fix

### DIFF
--- a/snippets/scss.php
+++ b/snippets/scss.php
@@ -18,7 +18,7 @@ $CSS          = $root . '/assets/css/'  . $template . '.css';
 $CSSKirbyPath = 'assets/css/' . $template . '.css';
 
 // Set default SCSS if there is no SCSS for current template. If template is default, skip check.
-if ($template = 'default' or !file_exists($SCSS)) {
+if ($template == 'default' or !file_exists($SCSS)) {
 	$SCSS         = $root . '/assets/scss/default.scss';
 	$CSS          = $root . '/assets/css/default.css';
 	$CSSKirbyPath = 'assets/css/default.css';


### PR DESCRIPTION
I've updated the expression inside the "if" block where you check whether the page template is the "default" template. The expression was assigning the value "default" to the $template variable instead of checking equivalence.
