### PR TITLE
 Fix link to multi environment setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a preprocessor for SCSS files. Built using the [scssphp library](https:/
 4. Create a folder ‘scss’ inside Kirby’s assets folder.
 5. Create a file ‘default.scss’ and place it inside ‘assets/scss’.
 6. Make sure the folder ‘assets/css’ exists on your server.
-7. Add `c::set('scssNestedCheck', true);` to the config of your dev environment. [Read more about multi environment setup for Kirby](https://getkirby.com/blog/multi-environment-setup).
+7. Add `c::set('scssNestedCheck', true);` to the config of your dev environment. [Read more about multi environment setup for Kirby](https://getkirby.com/docs/developer-guide/configuration/options#multi-environment-setup).
 
 ## Using SCSS plugin
 


### PR DESCRIPTION
I found and fixed an outdated link in the documentation while configuring your plugin.